### PR TITLE
Allow "Time on Battery before Shutdown (Minutes):" to be more than 1 hour

### DIFF
--- a/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_helpers.php
+++ b/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_helpers.php
@@ -39,7 +39,7 @@ function nut_get_battery_options($selected=20){
 /* get options for time intervals */
 function nut_get_minute_options($time){
     $options = '';
-        for($i = 1; $i <= 60; $i++){
+        for($i = 1; $i <= 180; $i++){
             $options .= '<option value="'.($i*60).'"';
 
             if(intval($time) === ($i*60)) {


### PR DESCRIPTION
Allow "Time on Battery before Shutdown (Minutes):" to be set to 180 minutes (3h)

I have a Eton Ellipse PRO 1600 with extra battries (x2), the time remaining is always incorrect so I cant use that. 

My runtime execedes the 60 minutes allowed in the dropdown as it has extra battery and not much load (less than 17%).

Last night I had a power outage for ~2h and my NAS turned off after 60 minutes (as it was set to), however I would like to be able to set it to a longer time.

Not sure if just adding extra things to the dropdown is enough to achive what I want though.