### PR TITLE
Update UPS power metric display

### DIFF
--- a/source/nut-dw/usr/local/emhttp/plugins/nut-dw/NUTsettings.page
+++ b/source/nut-dw/usr/local/emhttp/plugins/nut-dw/NUTsettings.page
@@ -44,7 +44,7 @@ if (file_exists('/usr/local/emhttp/plugins/nut-dw/misc/start-failed')) {
 </style>
 
 <table class="tablesorter shift nut" <?if (!$nut_running):?>style="display:none"<?endif;?>>
-<thead><tr><th>UPS Status</th><th>Battery Charge</th><th>Runtime Left</th><th>Nominal Power</th><th>UPS Load</th><th>UPS Load</th><th>Power Factor</th></tr></thead>
+<thead><tr><th>UPS Status</th><th>Battery Charge</th><th>Runtime Left</th><th>Nominal Power</th><th>Power Draw</th><th>UPS Load</th><th>Power Factor</th></tr></thead>
 <tbody id="nut_summary"><tr><td colspan="7" style="text-align:center"><i class="fa fa-spinner fa-spin"></i> <em>Please wait, retrieving UPS information...</em></td></tr></tbody>
 </table>
 
@@ -963,7 +963,8 @@ if (file_exists('/usr/local/emhttp/plugins/nut-dw/misc/start-failed')) {
     </dl>
 
     <blockquote class="inline_help">
-        <p>Settings for UPS Nominal Watt Capacity (W) and UPS Nominal Volt Ampere Capacity (VA), used to calculate the W/VA consumption (and PF):</p>
+        <p>Settings for overriding the UPS nominal Watt (W) and Volt Ampere (VA) capacities. These ratings may be used to calculate load percentage from measured power and to show a clearly labelled nominal power factor.</p>
+        <p>Live W and VA are only displayed when the UPS reports those measurements; they are not calculated from load percentage.</p>
         <p>- <strong><em>Auto</em></strong> if the values reported by your UPS are correct (see <strong><em>NUT Details</em></strong> table).</p>
         <p>- <strong><em>Manual</em></strong> if the values reported by your UPS are incorrect (see <strong><em>NUT Details</em></strong> table).</p>
     </blockquote>
@@ -980,8 +981,8 @@ if (file_exists('/usr/local/emhttp/plugins/nut-dw/misc/start-failed')) {
             <p>This setting lets you override the UPS Nominal Watt Capacity (W) value.</p>
             <p>A <strong><em>negative</em></strong> value overrides the nominal W (as positive), but still allows the UPS-reported live W to be used for calculations.</p>
             <p><strong><em>Use a negative value if the UPS-reported nominal W is missing or incorrect, but the UPS-reported live W is correct.</em></strong></p>
-            <p>A <strong><em>positive</em></strong> value overrides the nominal W and also affects the UPS-reported live W by forcing recalculation based on load.</p>
-            <p><strong><em>Use a positive value if the UPS-reported live W, or both UPS-reported nominal W and live W, are missing or incorrect.</em></strong></p>
+            <p>A <strong><em>positive</em></strong> value overrides the nominal W and hides the UPS-reported live W. It does not calculate a replacement live W from load percentage.</p>
+            <p><strong><em>Use a positive value if the UPS-reported live W is incorrect and should not be displayed.</em></strong></p>
             <p><em>Special Case:</em> A <strong>-1</strong> value disables the nominal W override (if you just want to override nominal VA).</p>
             <p><em>Special Case:</em> A <strong>0</strong> value hides the nominal W completely, but still allows the UPS-reported live W to be used for calculations.</p>
         </blockquote>
@@ -997,8 +998,8 @@ if (file_exists('/usr/local/emhttp/plugins/nut-dw/misc/start-failed')) {
             <p>This setting lets you override the UPS Nominal Volt Ampere Capacity (VA) value.</p>
             <p>A <strong><em>negative</em></strong> value overrides the nominal VA (as positive), but still allows the UPS-reported live VA to be used for calculations.</p>
             <p><strong><em>Use a negative value if the UPS-reported nominal VA is missing or incorrect, but the UPS-reported live VA is correct.</em></strong></p>
-            <p>A <strong><em>positive</em></strong> value overrides the nominal VA and also affects the UPS-reported live VA by forcing recalculation based on load.</p>
-            <p><strong><em>Use a positive value if the UPS-reported live VA, or both UPS-reported nominal VA and live VA, are missing or incorrect.</em></strong></p>
+            <p>A <strong><em>positive</em></strong> value overrides the nominal VA and hides the UPS-reported live VA. It does not calculate a replacement live VA from load percentage.</p>
+            <p><strong><em>Use a positive value if the UPS-reported live VA is incorrect and should not be displayed.</em></strong></p>
             <p><em>Special Case:</em> A <strong>-1</strong> value disables the nominal VA override (if you just want to override nominal W).</p>
             <p><em>Special Case:</em> A <strong>0</strong> value hides the nominal VA completely, but still allows the UPS-reported live VA to be used for calculations.</p>
         </blockquote>

--- a/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_footer.php
+++ b/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_footer.php
@@ -62,37 +62,13 @@ try {
     if (count($ups_status)) {
         $online           = (array_key_exists("ups.status", $ups_status) ? nut_ups_status([$ups_status["ups.status"]], true) : false );
         $battery          = (array_key_exists("battery.charge",$ups_status)) ? intval(strtok($ups_status['battery.charge'],' ')) : false;
-        $load             = (array_key_exists("ups.load", $ups_status)) ? intval(strtok($ups_status['ups.load'],' ')) : 0;
-        $realPower        = (array_key_exists("ups.realpower", $ups_status)) ? intval(strtok($ups_status['ups.realpower'],' ')) : NULL;
-        $realPowerNominal = (array_key_exists("ups.realpower.nominal", $ups_status)) ? intval(strtok($ups_status['ups.realpower.nominal'],' ')) : NULL;
-        $apparentPower    = (array_key_exists("ups.power", $ups_status)) ? intval(strtok($ups_status['ups.power'],' ')) : NULL;
-        $powerNominal     = (array_key_exists("ups.power.nominal", $ups_status)) ? intval(strtok($ups_status['ups.power.nominal'],' ')) : NULL;
-
-        if ($nut_power == 'manual') {
-            # handle nominal VA
-            $manual_powerva = intval($nut_powerva);
-            if ($manual_powerva != -1) { # -1 disables override (use UPS nominal)
-                $powerNominal = abs($manual_powerva); # Make it positive
-
-                if ($manual_powerva > 0) {
-                    # Positive value -> override nominal VA and affect live consumption VA
-                    $apparentPower = 0;
-                }
-                # negative or 0 -> override nominal but do not affect live VA
-            }
-
-            # Handle nominal W
-            $manual_powerw = intval($nut_powerw);
-            if ($manual_powerw != -1) { # -1 disables override (use UPS nominal)
-                $realPowerNominal = abs($manual_powerw); # Make it positive
-
-                if ($manual_powerw > 0) {
-                    # Positive value -> override nominal W and affect live consumption W
-                    $realPower = 0;
-                }
-                # negative or 0 -> override nominal but do not affect live W
-            }
-        }
+        $powerMetrics = nut_power_metrics($ups_status, [
+            'manual' => $nut_power == 'manual',
+            'powerva' => $nut_powerva,
+            'powerw' => $nut_powerw,
+            'force_load' => $nut_loadcalc == 'enable',
+            'load_unit' => $nut_loadunit,
+        ]);
 
         $ups_alarm = nut_array_key_exists_wildcard($ups_status, '*ups.alarm*');
         if (count($ups_alarm)) {
@@ -140,44 +116,11 @@ try {
 
         $status[1] = "<span id='" . ($nut_footer_style == 0 ? "nut_battery" : "") . "' class='".($nut_footer_style == 0 || $online['severity'] > 0 ? "tooltip-nut" : "")." " . $css_class . "'" . $statusTooltipData . "><i class='fa " . $fa_icon . "' style='vertical-align: baseline;'></i>&thinsp;" . $batteryText . "</span>";
 
-        # if no ups.load compute from ups.power(.nominal) or ups.realpower(.nominal)
-        # also compute if calculation is otherwise forced by user setting
-        if ($load <= 0 || $nut_loadcalc == "enable") {
-            $loadW = 0; $loadVA = 0;
-            if ($realPower > 0 && $realPowerNominal > 0) $loadW = round($realPower / $realPowerNominal  * 100);
-            if ($apparentPower > 0 && $powerNominal > 0) $loadVA = round($apparentPower / $powerNominal  * 100);
-            if ($nut_loadunit == "W" && $loadW > 1 && $loadW < 101) $load = $loadW;
-            if ($nut_loadunit == "VA" && $loadVA > 1 && $loadVA < 101) $load = $loadVA;
-        }
-
-        # if no ups.power compute from load and ups.power.nominal
-        if ($apparentPower <= 0) $apparentPower = $powerNominal > 0 && $load ? round($powerNominal * $load * 0.01) : 0;
-
-        # if no ups.realpower compute from load and ups.realpower.nominal (in W)
-        if ($realPower <= 0) $realPower = $realPowerNominal > 0 && $load ? round($realPowerNominal * $load * 0.01) : 0;
-
-        $powerText = '';
-        $powerTooltipData = '';
-
-        if ($realPower > 0 && $apparentPower > 0) {
-            # display load, real and apparent power
-            $powerText = "{$realPower}&thinsp;W&thinsp;({$apparentPower}&thinsp;VA)";
-            $powerTooltipData = "Load: $load&thinsp;% - Real Power: $realPower&thinsp;W - Apparent Power: $apparentPower&thinsp;VA";
-        } elseif ($realPower > 0 && $load) {
-            # display load and real power
-            $powerText = "{$realPower}&thinsp;W";
-            $powerTooltipData = "Load: $load&thinsp;% - Real Power: $realPower&thinsp;W";
-        } elseif ($apparentPower > 0 && $load) {
-            # display load and apparent power
-            $powerText = "{$apparentPower}&thinsp;VA";
-            $powerTooltipData = "Load: $load&thinsp;% - Apparent Power: $apparentPower&thinsp;VA";
-        } elseif ($load) {
-            # display load
-            $powerText = "{$load}&thinsp;%";
-            $powerTooltipData = "Load: $load&thinsp;%";
-        }
-
-        $powerTooltipData = " data='<b>NUT Power Metrics:</b><br>[{$nut_name}] " . $powerTooltipData . "'";
+        # Prefer measured power in the footer, with load percentage as fallback.
+        $powerDisplay = nut_power_display($powerMetrics);
+        $powerText = $powerDisplay['text'];
+        $powerTooltipData = " data='<b>NUT Power Metrics:</b><br>[{$nut_name}] "
+            . $powerDisplay['details'] . "'";
 
         # show connected clients in netserver mode
         if ($nut_mode == "netserver" && $nut_footer_conns !== "disable") {
@@ -202,7 +145,12 @@ try {
                 unset($status[3]);
             }
         }
-        $status[2] = "<span id='".($nut_footer_style == 0 ? "nut_power" : "")."' class='".($nut_footer_style == 0 || $load >= 90 ? "tooltip-nut" : "")." " . ($load >= 90 ? $red : ($nut_footer_style == 1 ? $black : $green)) . "'" . $powerTooltipData . "><i class='fa fa-plug'></i>&thinsp;" . $powerText . "</span>";
+        $highLoad = $powerDisplay['high_load'];
+        $powerClass = $highLoad ? $red : ($nut_footer_style == 1 ? $black : $green);
+        $status[2] = "<span id='" . ($nut_footer_style == 0 ? "nut_power" : "")
+            . "' class='" . ($nut_footer_style == 0 || $highLoad ? "tooltip-nut" : "")
+            . " " . $powerClass . "'" . $powerTooltipData
+            . "><i class='fa fa-plug'></i>&thinsp;" . $powerText . "</span>";
 
         if($nut_syslog_method == "file" || $nut_syslog_method == "both") {
             if(file_exists("/var/log/nut.log")) {

--- a/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_helpers.php
+++ b/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_helpers.php
@@ -46,6 +46,9 @@ function nut_status_rows($name, $ip) {
         'output.frequency',
         'output.power.nominal', // according to user reports for UniFi UPS
         'output.power', // according to user reports for UniFi UPS
+        'output.powerfactor',
+        'output.realpower.nominal',
+        'output.realpower',
         'output.voltage',
         'ups.id',
         'ups.load',
@@ -53,6 +56,7 @@ function nut_status_rows($name, $ip) {
         'ups.model',
         'ups.power.nominal',
         'ups.power',
+        'ups.powerfactor',
         'ups.realpower.nominal',
         'ups.realpower',
         'ups.serial',
@@ -84,6 +88,155 @@ function nut_status_rows($name, $ip) {
     }
 
     return $rows;
+}
+
+function nut_numeric_variable($values, $names) {
+    foreach ($names as $name) {
+        if (!array_key_exists($name, $values)) continue;
+
+        $value = strtok(trim((string)$values[$name]), ' ');
+        if (is_numeric($value)) return (float)$value;
+    }
+
+    return null;
+}
+
+function nut_power_metric_available($value) {
+    return $value !== null && is_numeric($value) && $value >= 0;
+}
+
+function nut_apply_power_overrides($metrics, $options) {
+    if (empty($options['manual'])) return $metrics;
+
+    // -1 keeps the UPS value. Negative values replace only the nominal
+    // rating, zero hides it, and positive values also hide the live value.
+    $manualVA = isset($options['powerva']) ? intval($options['powerva']) : -1;
+    if ($manualVA !== -1) {
+        $metrics['apparent_nominal'] = abs($manualVA);
+        if ($manualVA > 0) $metrics['apparent'] = null;
+    }
+
+    $manualW = isset($options['powerw']) ? intval($options['powerw']) : -1;
+    if ($manualW !== -1) {
+        $metrics['real_nominal'] = abs($manualW);
+        if ($manualW > 0) $metrics['real'] = null;
+    }
+
+    return $metrics;
+}
+
+function nut_power_load_percentage($measured, $nominal) {
+    if ($measured === null || $measured < 0 || $nominal === null || $nominal <= 0) return null;
+
+    $load = round($measured / $nominal * 100);
+
+    return $load >= 0 && $load <= 100 ? $load : null;
+}
+
+function nut_calculate_power_load($metrics, $options) {
+    if ($metrics['load'] !== null && $metrics['load'] > 0 && empty($options['force_load'])) return $metrics;
+
+    // Load may be derived from measured and nominal power, but a reported
+    // load percentage must never be used to invent live VA or W readings.
+    $loadW = nut_power_load_percentage($metrics['real'], $metrics['real_nominal']);
+    $loadVA = nut_power_load_percentage($metrics['apparent'], $metrics['apparent_nominal']);
+    $loadUnit = isset($options['load_unit']) ? $options['load_unit'] : 'W';
+
+    if ($loadUnit === 'VA' && $loadVA !== null) $metrics['load'] = $loadVA;
+    if ($loadUnit === 'W' && $loadW !== null) $metrics['load'] = $loadW;
+
+    return $metrics;
+}
+
+function nut_power_factor_ratio($realPower, $apparentPower) {
+    if ($realPower === null || $realPower < 0 || $apparentPower === null || $apparentPower <= 0) return null;
+    if ($realPower > $apparentPower) return null;
+
+    return $realPower / $apparentPower;
+}
+
+function nut_add_power_factor($metrics, $values) {
+    // Prefer NUT's standard output value, then measured W/VA, and finally the
+    // nominal ratio. The UPS-level name remains as a compatibility fallback.
+    $directPowerFactor = nut_numeric_variable(
+        $values,
+        ['output.powerfactor', 'ups.powerfactor']
+    );
+    if ($directPowerFactor !== null && $directPowerFactor > 0 && $directPowerFactor <= 1) {
+        $metrics['power_factor'] = $directPowerFactor;
+        $metrics['power_factor_source'] = 'direct';
+
+        return $metrics;
+    }
+
+    $measuredPowerFactor = nut_power_factor_ratio($metrics['real'], $metrics['apparent']);
+    if ($measuredPowerFactor !== null) {
+        $metrics['power_factor'] = $measuredPowerFactor;
+        $metrics['power_factor_source'] = 'measured';
+
+        return $metrics;
+    }
+
+    $nominalPowerFactor = nut_power_factor_ratio($metrics['real_nominal'], $metrics['apparent_nominal']);
+    if ($nominalPowerFactor !== null && $nominalPowerFactor > 0) {
+        $metrics['power_factor'] = $nominalPowerFactor;
+        $metrics['power_factor_source'] = 'nominal';
+    }
+
+    return $metrics;
+}
+
+function nut_power_metrics($values, $options = []) {
+    // Canonical aggregate NUT names take precedence over legacy output aliases.
+    $metrics = [
+        'load' => nut_numeric_variable($values, ['ups.load']),
+        'apparent' => nut_numeric_variable($values, ['ups.power', 'output.power']),
+        'apparent_nominal' => nut_numeric_variable($values, ['ups.power.nominal', 'output.power.nominal']),
+        'real' => nut_numeric_variable($values, ['ups.realpower', 'output.realpower']),
+        'real_nominal' => nut_numeric_variable($values, ['ups.realpower.nominal', 'output.realpower.nominal']),
+        'power_factor' => null,
+        'power_factor_source' => null,
+    ];
+
+    $metrics = nut_apply_power_overrides($metrics, $options);
+    $metrics = nut_calculate_power_load($metrics, $options);
+
+    return nut_add_power_factor($metrics, $values);
+}
+
+function nut_format_power_number($value) {
+    if ($value === null || !is_numeric($value)) return '';
+    if ((float)$value == (int)$value) return (string)(int)$value;
+
+    return rtrim(rtrim(number_format((float)$value, 2, '.', ''), '0'), '.');
+}
+
+function nut_power_display($metrics) {
+    $values = [];
+    $details = [];
+    $hasLoad = nut_power_metric_available($metrics['load']);
+
+    if ($hasLoad) {
+        $details[] = "Load: " . nut_format_power_number($metrics['load']) . "&thinsp;%";
+    }
+    if (nut_power_metric_available($metrics['real'])) {
+        $realPower = nut_format_power_number($metrics['real']);
+        $values[] = $realPower . "&thinsp;W";
+        $details[] = "Measured Real Power: " . $realPower . "&thinsp;W";
+    }
+    if (nut_power_metric_available($metrics['apparent'])) {
+        $apparentPower = nut_format_power_number($metrics['apparent']);
+        $values[] = $apparentPower . "&thinsp;VA";
+        $details[] = "Measured Apparent Power: " . $apparentPower . "&thinsp;VA";
+    }
+
+    return [
+        'text' => !empty($values)
+            ? implode(' / ', $values)
+            : ($hasLoad ? nut_format_power_number($metrics['load']) . "&thinsp;%" : ''),
+        'details' => implode(' - ', $details),
+        'high_load' => $hasLoad && $metrics['load'] >= 90,
+    ];
 }
 
 /* get options for battery level */

--- a/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_status.php
+++ b/source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_status.php
@@ -62,11 +62,7 @@ try {
         $upsStatus = nut_ups_status($rows);
 
         $runtime = 0;
-        $realPower = 0;
-        $realPowerNominal = 0;
-        $apparentPower = 0;
-        $powerNominal = 0;
-        $load = 0;
+        $upsValues = [];
 
         $descriptorMapping = [];
         $descriptorFilePath = '/usr/share/nut/cmdvartab';
@@ -89,6 +85,7 @@ try {
             $row = array_map('trim', explode(':', $rows[$i], 2));
             $key = $row[0];
             $val = $row[1];
+            $upsValues[$key] = $val;
 
             switch ($key) {
                 case 'ups.status':
@@ -112,21 +109,6 @@ try {
                     $runtime   = $nut_rtunit == "minutes" ? gmdate("H:i:s", round($val*60)) : gmdate("H:i:s", round($val));
                     $status[2] = strtok(($nut_rtunit == "minutes" ? round($val) : round($val/60)),' ')<=5 && !in_array('ups.status: OL', $rows) ? "<td $red>$runtime</td>" : "<td $green>$runtime</td>";
                     break;
-                case 'ups.realpower':
-                    $realPower = strtok($val, ' ');
-                    break;
-                case 'ups.realpower.nominal':
-                    $realPowerNominal = strtok($val,' ');
-                    break;
-                case 'ups.power':
-                    $apparentPower = strtok($val, ' ');
-                    break;
-                case 'ups.power.nominal':
-                    $powerNominal = strtok($val,' ');
-                    break;
-                case 'ups.load':
-                    $load      = strtok($val,' ');
-                    break;
             }
 
             if ($all) {
@@ -142,76 +124,61 @@ try {
             }
         }
 
-        if ($nut_power == 'manual') {
-            # handle nominal VA
-            $manual_powerva = intval($nut_powerva);
-            if ($manual_powerva != -1) { # -1 disables override (use UPS nominal)
-                $powerNominal = abs($manual_powerva); # Make it positive
+        $powerMetrics = nut_power_metrics($upsValues, [
+            'manual' => $nut_power == 'manual',
+            'powerva' => $nut_powerva,
+            'powerw' => $nut_powerw,
+            'force_load' => $nut_loadcalc == 'enable',
+            'load_unit' => $nut_loadunit,
+        ]);
+        $realPower = $powerMetrics['real'];
+        $realPowerNominal = $powerMetrics['real_nominal'];
+        $apparentPower = $powerMetrics['apparent'];
+        $powerNominal = $powerMetrics['apparent_nominal'];
+        $load = $powerMetrics['load'];
 
-                if ($manual_powerva > 0) {
-                    # Positive value -> override nominal VA and affect live consumption VA
-                    $apparentPower = 0;
-                }
-                # negative or 0 -> override nominal but do not affect live VA
-            }
+        $hasLoad = nut_power_metric_available($load);
+        $highLoad = $hasLoad && $load >= 90;
+        $powerColor = $highLoad ? $red : $green;
 
-            # Handle nominal W
-            $manual_powerw = intval($nut_powerw);
-            if ($manual_powerw != -1) { # -1 disables override (use UPS nominal)
-                $realPowerNominal = abs($manual_powerw); # Make it positive
-
-                if ($manual_powerw > 0) {
-                    # Positive value -> override nominal W and affect live consumption W
-                    $realPower = 0;
-                }
-                # negative or 0 -> override nominal but do not affect live W
-            }
+        if ($hasLoad) {
+            $status[5] = "<td $powerColor>"
+                . nut_format_power_number($load) . "&thinsp;%</td>";
         }
-
-        # if no ups.load compute from ups.power(.nominal) or ups.realpower(.nominal)
-        # also compute if calculation is otherwise forced by user setting
-        if ($load <= 0 || $nut_loadcalc == "enable") {
-            $loadW = 0; $loadVA = 0;
-            if ($realPower > 0 && $realPowerNominal > 0) $loadW = round($realPower / $realPowerNominal  * 100);
-            if ($apparentPower > 0 && $powerNominal > 0) $loadVA = round($apparentPower / $powerNominal  * 100);
-            if ($nut_loadunit == "W" && $loadW > 1 && $loadW < 101) $load = $loadW;
-            if ($nut_loadunit == "VA" && $loadVA > 1 && $loadVA < 101) $load = $loadVA;
-        }
-
-        if ($load > 0) {
-            $status[5] = $load>=90 ? "<td $red>".intval($load). "&thinsp;%</td>" : "<td $green>".intval($load). "&thinsp;%</td>";
-        }
-
-        # if no ups.power compute from load and ups.power.nominal
-        if ($apparentPower <= 0) $apparentPower = $powerNominal > 0 && $load ? round($powerNominal * $load * 0.01) : 0;
-
-        # if no ups.realpower compute from load and ups.realpower.nominal (in W)
-        if ($realPower <= 0) $realPower = $realPowerNominal > 0 && $load ? round($realPowerNominal * $load * 0.01) : 0;
 
         if ($powerNominal > 0 && $realPowerNominal > 0) {
-            $status[3] = "<td $green>$realPowerNominal&thinsp;W ($powerNominal&thinsp;VA)</td>";
+            $status[3] = "<td $green>"
+                . nut_format_power_number($realPowerNominal) . "&thinsp;W / "
+                . nut_format_power_number($powerNominal) . "&thinsp;VA</td>";
         } elseif ($powerNominal > 0) {
-            $status[3] = "<td $green>$powerNominal&thinsp;VA</td>";
+            $status[3] = "<td $green>"
+                . nut_format_power_number($powerNominal) . "&thinsp;VA</td>";
         } elseif ($realPowerNominal > 0) {
-            $status[3] = "<td $green>$realPowerNominal&thinsp;W</td>";
+            $status[3] = "<td $green>"
+                . nut_format_power_number($realPowerNominal) . "&thinsp;W</td>";
         }
 
-        # display apparent power and real power if exists
-        if ($apparentPower > 0 && $realPower > 0) {
-            $status[4] = "<td " . ($load >= 90 ? $red : $green) . ">$realPower&thinsp;W ($apparentPower&thinsp;VA)</td>";
-        } elseif ($apparentPower > 0) {
-            $status[4] = "<td " . ($load >= 90 ? $red : $green) . ">$apparentPower&thinsp;VA</td>";
-        } elseif ($realPower > 0) {
-            $status[4] = "<td " . ($load >= 90 ? $red : $green) . ">$realPower&thinsp;W</td>";
+        # Display each measured power value independently, including zero.
+        $hasApparentPower = nut_power_metric_available($apparentPower);
+        $hasRealPower = nut_power_metric_available($realPower);
+        if ($hasApparentPower && $hasRealPower) {
+            $status[4] = "<td $powerColor>"
+                . nut_format_power_number($realPower) . "&thinsp;W / "
+                . nut_format_power_number($apparentPower) . "&thinsp;VA</td>";
+        } elseif ($hasApparentPower) {
+            $status[4] = "<td $powerColor>"
+                . nut_format_power_number($apparentPower) . "&thinsp;VA</td>";
+        } elseif ($hasRealPower) {
+            $status[4] = "<td $powerColor>"
+                . nut_format_power_number($realPower) . "&thinsp;W</td>";
         }
 
-        if ($realPower > 0 && $apparentPower > 0) {
-            # compute output power factor from real power and apparent power if available
-            $status[6] = "<td $green>".round($realPower / $apparentPower, 2)."</td>";
-        }
-        elseif ($realPowerNominal > 0 && $powerNominal > 0) {
-            # or present nominal power factor from ups.realpower.nominal and ups.power.nominal if available
-            $status[6] = "<td $green>".round($realPowerNominal / $powerNominal, 2)."</td>";
+        if ($powerMetrics['power_factor'] !== null) {
+            $powerFactorLabel = $powerMetrics['power_factor_source'] === 'nominal'
+                ? ' (nominal)'
+                : '';
+            $status[6] = "<td $green>" . round($powerMetrics['power_factor'], 2)
+                . $powerFactorLabel . "</td>";
         }
 
         if ($all && count($rows)%2==1) $result[] = "<td></td><td></td></tr>";

--- a/tests/power_metrics_test.php
+++ b/tests/power_metrics_test.php
@@ -1,0 +1,105 @@
+<?php
+ini_set('short_open_tag', '1');
+require_once __DIR__ . '/../source/nut-dw/usr/local/emhttp/plugins/nut-dw/include/nut_helpers.php';
+
+function expect_equal($actual, $expected, $message) {
+    if ($actual !== $expected) {
+        fwrite(STDERR, "$message: expected " . var_export($expected, true)
+            . ", got " . var_export($actual, true) . PHP_EOL);
+        exit(1);
+    }
+}
+
+$canonical = nut_power_metrics([
+    'ups.power' => '500', 'output.power' => '400',
+    'ups.realpower' => '450', 'output.realpower' => '350',
+    'ups.power.nominal' => '1000', 'ups.realpower.nominal' => '900',
+    'ups.load' => '45',
+]);
+expect_equal($canonical['apparent'], 500.0, 'canonical apparent power wins');
+expect_equal($canonical['real'], 450.0, 'canonical real power wins');
+expect_equal($canonical['power_factor_source'], 'measured', 'measured power factor source');
+
+$legacy = nut_power_metrics([
+    'output.power' => '500', 'output.realpower' => '400',
+    'output.power.nominal' => '1000', 'output.realpower.nominal' => '900',
+]);
+expect_equal($legacy['apparent'], 500.0, 'legacy apparent alias');
+expect_equal($legacy['real_nominal'], 900.0, 'legacy nominal real alias');
+
+$realOnlyDisplay = nut_power_display(nut_power_metrics(['ups.realpower' => '125']));
+expect_equal($realOnlyDisplay['text'], '125&thinsp;W', 'real power displays without load');
+
+$apparentOnlyDisplay = nut_power_display(nut_power_metrics(['ups.power' => '150']));
+expect_equal($apparentOnlyDisplay['text'], '150&thinsp;VA', 'apparent power displays without load');
+
+$noSynthesis = nut_power_metrics([
+    'ups.load' => '37', 'ups.power.nominal' => '1000',
+    'ups.realpower.nominal' => '900',
+]);
+expect_equal($noSynthesis['apparent'], null, 'load must not synthesize apparent power');
+expect_equal($noSynthesis['real'], null, 'load must not synthesize real power');
+expect_equal($noSynthesis['power_factor_source'], 'nominal', 'nominal ratio is labelled nominal');
+
+$direct = nut_power_metrics([
+    'ups.power' => '500', 'ups.realpower' => '300', 'output.powerfactor' => '0.95',
+]);
+expect_equal($direct['power_factor'], 0.95, 'direct power factor wins');
+expect_equal($direct['power_factor_source'], 'direct', 'direct power factor source');
+
+$canonicalDirect = nut_power_metrics([
+    'ups.powerfactor' => '0.91', 'output.powerfactor' => '0.89',
+]);
+expect_equal($canonicalDirect['power_factor'], 0.89, 'standard output power factor wins');
+
+$invalidLive = nut_power_metrics([
+    'ups.power' => '300', 'ups.realpower' => '400',
+]);
+expect_equal($invalidLive['power_factor'], null, 'physically invalid live ratio is omitted');
+
+$zero = nut_power_metrics(['ups.power' => '0', 'ups.realpower' => '0', 'ups.load' => '0']);
+expect_equal($zero['apparent'], 0.0, 'legitimate measured zero is retained');
+expect_equal($zero['real'], 0.0, 'legitimate measured real zero is retained');
+expect_equal(nut_power_metric_available($zero['apparent']), true, 'measured zero is displayable');
+expect_equal(nut_power_metric_available(null), false, 'missing measurement is not displayable');
+expect_equal(nut_power_metric_available(-1), false, 'negative sentinel is not displayable');
+$zeroDisplay = nut_power_display($zero);
+expect_equal($zeroDisplay['text'], '0&thinsp;W / 0&thinsp;VA', 'measured zero is displayed');
+
+$loadOnlyDisplay = nut_power_display(nut_power_metrics(['ups.load' => '91']));
+expect_equal($loadOnlyDisplay['text'], '91&thinsp;%', 'load remains a display fallback');
+expect_equal($loadOnlyDisplay['high_load'], true, 'high load retains warning state');
+
+$manualNegative = nut_power_metrics([
+    'ups.power' => '500', 'ups.power.nominal' => '1000',
+    'ups.realpower' => '400', 'ups.realpower.nominal' => '900',
+], [
+    'manual' => true, 'powerva' => '-1200', 'powerw' => '-950',
+]);
+expect_equal($manualNegative['apparent_nominal'], 1200, 'negative manual VA overrides nominal');
+expect_equal($manualNegative['real_nominal'], 950, 'negative manual W overrides nominal');
+expect_equal($manualNegative['apparent'], 500.0, 'negative manual VA retains live measurement');
+expect_equal($manualNegative['real'], 400.0, 'negative manual W retains live measurement');
+
+$manualPositive = nut_power_metrics([
+    'ups.power' => '500', 'ups.realpower' => '400',
+], [
+    'manual' => true, 'powerva' => '1200', 'powerw' => '950',
+]);
+expect_equal($manualPositive['apparent_nominal'], 1200, 'positive manual VA overrides nominal');
+expect_equal($manualPositive['real_nominal'], 950, 'positive manual W overrides nominal');
+expect_equal($manualPositive['apparent'], null, 'positive manual VA hides live measurement');
+expect_equal($manualPositive['real'], null, 'positive manual W hides live measurement');
+
+$manualSpecial = nut_power_metrics([
+    'ups.power' => '500', 'ups.power.nominal' => '1000',
+    'ups.realpower' => '400', 'ups.realpower.nominal' => '900',
+], [
+    'manual' => true, 'powerva' => '0', 'powerw' => '-1',
+]);
+expect_equal($manualSpecial['apparent_nominal'], 0, 'zero manual VA hides nominal');
+expect_equal($manualSpecial['apparent'], 500.0, 'zero manual VA retains live measurement');
+expect_equal($manualSpecial['real_nominal'], 900.0, '-1 manual W keeps UPS nominal');
+expect_equal($manualSpecial['real'], 400.0, '-1 manual W keeps live measurement');
+
+fwrite(STDOUT, "power metrics tests passed" . PHP_EOL);


### PR DESCRIPTION
## Summary

While testing a new SNMP driver, I found that the WebUI could turn `ups.load` and the nominal UPS ratings into apparent and real power values. That made calculated estimates look like measurements reported by the UPS.

This change keeps load percentage and power draw separate. It also adds support for the full set of canonical NUT power variables while keeping the older `output.*` names working for existing devices.

## What changed

Power handling is now shared between the main status page and footer instead of each having its own version of the same logic.

The helper now prefers:

- `ups.power` and `ups.power.nominal` for apparent VA
- `ups.realpower` and `ups.realpower.nominal` for real W
- `ups.load` for load percentage.

It falls back to `output.power*` and `output.realpower*` when the canonical variables are not available. This keeps compatibility with drivers which only expose the older names.

Measured VA and W are displayed independently, as are nominal VA and W. A device which reports only watts can now show those watts without needing `ups.load` or a matching VA value. A real zero reading is also kept instead of being treated as missing.

The UI no longer calculates live W or VA from rounded load percentage. It can still calculate a missing load percentage from measured and nominal power when the existing setting requests that behaviour, but that calculation only runs in that direction.

Power factor is selected in this order:

1. use a valid value reported directly by the UPS;
2. calculate it when both measured W and VA are available and physically valid; or
3. fall back to nominal W/VA and label it `(nominal)`.

The duplicate `UPS Load` heading in the settings summary is renamed `Power Draw`, so it is clearer which value is a percentage and which is an electrical measurement.

The existing manual power overrides are retained. `-1` keeps the UPS value, a negative value changes the nominal rating but keeps the live measurement, zero hides the nominal rating, and a positive value also hides the live value that the user has chosen to override.

## Files

- `include/nut_helpers.php` contains the shared selection, validation, power-factor and formatting logic.
- `include/nut_status.php` and `include/nut_footer.php` use that shared result.
- `NUTsettings.page` uses the clearer `Power Draw` label and updates the power override help text.
- `tests/power_metrics_test.php` covers the new behaviour.

After CodeFactor flagged the first version of the shared helper as too complex, I split the manual override, load calculation and power-factor handling into smaller functions. The comments are kept around the less obvious precedence and calculation rules.

## Testing

The regression test covers canonical and legacy variable names, W-only and VA-only devices, valid zero readings, load-only fallback, manual override modes, power-factor selection and invalid physical ratios. It also checks that load percentage cannot create a live W or VA reading.

I ran PHP syntax checks for every changed PHP/page file, ran the regression test in a checksum-pinned PHP container, and ran `git diff --check`. I also validated the deployment checksums and Docker Compose configuration.

I installed the final refactored files on Unraid 7.3.2 and tested them with a PowerShield Centurion RT 1000VA using the new [Voltronic NUT SNMP subdriver](https://github.com/networkupstools/nut/pull/3570).

That UPS reports measured real power, load percentage and nominal 900 W / 1000 VA ratings, but no measured apparent power or direct power factor (which is expected). The UI showed the measured watts and load separately. It did not invent a VA reading, and it correctly labelled the 0.9 nominal ratio as nominal.

OpenAI Codex helped with the implementation, test preparation and CodeFactor refactor. I reviewed the changes against the existing project style and tested the final version in the container and on the target Unraid system.
